### PR TITLE
Shorten package names in maintenance incidents targeting Leap, fixes #1

### DIFF
--- a/source/OBS.pm
+++ b/source/OBS.pm
@@ -47,6 +47,7 @@ sub fetch()
             next if $p eq "patchinfo";
             $p=~s/_NonFree_Update//;
             $p=~s/\.openSUSE_\d\d\.\d(_Update)?//;
+            $p=~s/\.openSUSE_Leap_\d\d\.\d(_Update)?//;
             $p=~s/\.SUSE_SLE-\d\d(-SP\d)?_Update//;
             $targetdistri->{$targetdistri1}=1;
             $package->{$p}=1;


### PR DESCRIPTION
Looks trivial, please review
